### PR TITLE
Set the qrSymbol in zodTypes to OPTIONAL

### DIFF
--- a/backend/src/zodTypes.ts
+++ b/backend/src/zodTypes.ts
@@ -63,7 +63,7 @@ export const tankMetaDataSchema = z.object({
   volume: z.number().int().positive(),
   type: z.enum(['FRESH', 'SALT', 'BRACKISH']),
 
-  qrSymbol: z.number().int().positive(),
+  qrSymbol: z.number().int().positive().optional(),
 
   tanknicianSourcedOnly: z.boolean(),
   lastDateServiced: z.date(),


### PR DESCRIPTION
The server creates the symbol. It's not required nor needed from the frontend. 