### PR TITLE
boolean params work now

### DIFF
--- a/backend/express-query-boolean.d.ts
+++ b/backend/express-query-boolean.d.ts
@@ -1,0 +1,5 @@
+declare module 'express-query-boolean' {
+  import { RequestHandler } from 'express';
+  function expressQueryBoolean(): RequestHandler;
+  export = expressQueryBoolean;
+}

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,6 +17,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
+        "express-query-boolean": "^2.0.0",
         "jsonwebtoken": "^9.0.0",
         "nodemailer": "^6.9.1",
         "nodemon": "^3.0.1",
@@ -5385,6 +5386,11 @@
       "engines": {
         "node": ">= 0.10.0"
       }
+    },
+    "node_modules/express-query-boolean": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/express-query-boolean/-/express-query-boolean-2.0.0.tgz",
+      "integrity": "sha512-4dU/1HPm8lkTPR12+HFUXqCarcsC19OKOkb4otLOuADfPYrQMaugPJkSmxNsqwmWYjozvT6vdTiqkgeBHkzOow=="
     },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
@@ -15061,6 +15067,11 @@
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         }
       }
+    },
+    "express-query-boolean": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/express-query-boolean/-/express-query-boolean-2.0.0.tgz",
+      "integrity": "sha512-4dU/1HPm8lkTPR12+HFUXqCarcsC19OKOkb4otLOuADfPYrQMaugPJkSmxNsqwmWYjozvT6vdTiqkgeBHkzOow=="
     },
     "fast-copy": {
       "version": "3.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -32,6 +32,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
+    "express-query-boolean": "^2.0.0",
     "jsonwebtoken": "^9.0.0",
     "nodemailer": "^6.9.1",
     "nodemon": "^3.0.1",

--- a/backend/src/Database/ServiceCall/Routes.ts
+++ b/backend/src/Database/ServiceCall/Routes.ts
@@ -40,7 +40,7 @@ serviceCallRouter.get(
   async (req, res) => {
     const result = z
       .object({
-        isApproved: z.coerce.boolean(),
+        isApproved: z.boolean().optional(),
       })
       .safeParse({ ...req.query });
     if (!result.success) {
@@ -117,13 +117,13 @@ serviceCallRouter.get(
     const result = z
       .object({
         tankId: z.coerce.number(),
-        isApproved: z.coerce.boolean(),
+        isApproved: z.boolean().optional(),
       })
       .safeParse({ ...req.query, ...req.params });
     if (!result.success) {
       return res.status(400).json({ error: result.error.errors });
     }
-    const { tankId, isApproved } = result.data;
+    const { tankId, isApproved = false } = result.data;
     try {
       const result = await ServiceCallService.readAllByTankId(
         tankId,

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,6 +1,7 @@
 import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import express from 'express';
+import booleanParser from 'express-query-boolean';
 
 import authRouter from './Authentication/Routes';
 import databaseRouter from './Database/Routes';
@@ -26,6 +27,7 @@ const corsOptions = {
 app.use(cors(corsOptions));
 app.use(httpLogger);
 app.use(cookieParser());
+app.use(booleanParser());
 
 // Service endpoints
 app


### PR DESCRIPTION
so before query params for booleans didn't work AT ALL.
```
'false' => true
'true' => true
'random string or anything truthy' => true
undefined => false
```

now:
```
'false' => false
'true' => true
undefined => undefined
'False' | 'True' | 'any string or non boolean value' => error
```

in the future, don't use coerce on z.boolean() unless that's what you want (it's probably not, `.optional() => some type | undefined` is usually the correct path).

`.coerce` on things like numbers and dates is still good tho